### PR TITLE
Linked weapon Swapping to events

### DIFF
--- a/quirklike/Assets/General Scripts/Callbacks.cs
+++ b/quirklike/Assets/General Scripts/Callbacks.cs
@@ -14,6 +14,16 @@ public class CallbackFloat:CallbackData
         this.value = value;
     }
 }
+public class CallbackTwoInts : CallbackData
+{
+    public int valueOne;
+    public int valueTwo;
+    public CallbackTwoInts(int valueOne, int valueTwo)
+    {
+        this.valueOne = valueOne;
+        this.valueTwo = valueTwo;
+    }
+}
 
 public class CallbackPlayerHitEnemyData : CallbackData
 {
@@ -50,7 +60,8 @@ public enum CallbackEvent
     PlayerKilled,
     PlayerHitEnemy,
     GameLost,
-    AreaComplete
+    AreaComplete,
+    SwapWeaponSlots,
 }
 
 
@@ -72,6 +83,7 @@ public static class Callbacks
     public static event System.Action<float,bool,GameObject,int> PlayerHitEnemy;
     public static event System.Action GameLost;
     public static event System.Action AreaComplete;
+    public static event System.Action<int,int> SwapWeaponSlots;
 
 
     public static void CallEvent(CallbackEvent callbackEvent, CallbackData data = null) //this can be called from anywhere, be careful
@@ -169,6 +181,13 @@ public static class Callbacks
                 {
                     Debug.Log("AREA COMPLETE");
                     AreaComplete?.Invoke();
+                    break;
+                }
+            case CallbackEvent.SwapWeaponSlots:
+                {
+                    Debug.Log("TRY SWAP WEAPONS");
+                    CallbackTwoInts slotIDs = (CallbackTwoInts)data;
+                    SwapWeaponSlots?.Invoke(slotIDs.valueOne, slotIDs.valueTwo);
                     break;
                 }
             default:

--- a/quirklike/Assets/Player/PlayerWeaponController.cs
+++ b/quirklike/Assets/Player/PlayerWeaponController.cs
@@ -45,11 +45,18 @@ public class PlayerWeaponController : MonoBehaviour
             if (weapon) AttachWeapon(weapon);
         }
     }
+    private void OnEnable()
+    {
+        Callbacks.SwapWeaponSlots += SwapWeaponSlots;
+    }
+    private void OnDisable()
+    {
+        Callbacks.SwapWeaponSlots -= SwapWeaponSlots;
+    }
 
     // Update is called once per frame
     void Update()
     {
-        if (Input.GetKeyDown(KeyCode.C)) SwapWeaponSlots(0, 1); //debug
         if (_playerInputManager.PlayerFireDown()) //change these to new input system
         {
             OnPlayerFireClicked?.Invoke();
@@ -63,6 +70,8 @@ public class PlayerWeaponController : MonoBehaviour
             OnPlayerFireReleased?.Invoke();
         }
     }
+
+
 
     void AttachAlreadyHeldWeapon(ref WeaponBase weapon) //used when the weapon is already in the current weapons list, might be needed sometimes idk
     {


### PR DESCRIPTION
- Connected weapon swapping to new event so it can be done wherever needed.
- This should have been in the previous pull but I forgot.